### PR TITLE
add-firebase-login

### DIFF
--- a/kei-doro/Pages/LoginPage/ViewModels/NFCViewModel.swift
+++ b/kei-doro/Pages/LoginPage/ViewModels/NFCViewModel.swift
@@ -1,10 +1,24 @@
 import SwiftUI
+import FirebaseFirestore
 
 class NFCViewModel: ObservableObject {
     var savedata: UserDefaults = UserDefaults.standard
+    let db = Firestore.firestore()
+ 
     
-    func saveUserId(UserId: String){
+    func saveUserId(UserId: String) async throws{
+        let document = try await db.collection("users").document(UserId).getDocument()
+        let data = document.data()
+        let userId = data?["id"]
+        if userId as? String == nil{
+            
+            
+            
+            
+            try await db.collection("users").document(UserId).setData([
+                "id": UserId,
+                "name": "guest"])
+        }
         
-        savedata.set(UserId, forKey: "userId")
     }
 }

--- a/kei-doro/Pages/LoginPage/Views/NFCView.swift
+++ b/kei-doro/Pages/LoginPage/Views/NFCView.swift
@@ -14,7 +14,15 @@ struct NFCView: View {
                                    alertMessage = error.localizedDescription
                                } else {
                                    alertMessage = "読み込みました！"
-                                   viewModel.saveUserId(UserId: text ?? "")
+                                   Task{
+                                       do{
+                                           try await viewModel.saveUserId(UserId: text ?? "")
+                                       }
+                                       catch{
+                                           print(error)
+                                       }
+                                   }
+                                  
                                    //違うNFC読み込まれた時どうしよう・・・
                                    
                                    


### PR DESCRIPTION
## やったこと
最初のnfc読み込み時にfirestoreにnfcのid名前が保存されるようになってます
## やっていないこと

## 影響範囲

## 補足

close #11 
